### PR TITLE
moved commands to .deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,5 @@ script:
   - make html && rm --force --recursive _build
 deploy:
   provider: script
-  script: |
-    git remote set-url origin "https://$USERNAME:$PASSWORD@github.com/cs50/manual50.git" && \
-    git branch --delete rel && \
-    git checkout -b rel && \
-    git add --all && \
-    git commit --message "$(date) [skip ci]" && \
-    git push --force origin rel
+  script: 'git remote set-url origin "https://$USERNAME:$PASSWORD@github.com/cs50/manual50.git" && git branch --delete rel && git checkout -b rel && git add --all && git commit --message "$(date) [skip ci]" && git push --force origin rel'
   skip_cleanup: true


### PR DESCRIPTION
Travis CI doesn't seem to like multi-line string as a value for the `script` in deployment configs.